### PR TITLE
Detect if  points to external json file

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -94,7 +94,11 @@ function processGlobalParameters(parameters, srGlobalRefParameters) {
 }
 
 function fixRef(ref) {
-  return '#/definitions/' + ref;
+  if (ref.indexOf('.json') == -1) {
+    return '#/definitions/' + ref;
+  } else {
+    return ref;
+  }
 }
 
 function applyOnProperty(schema, name, type, cb) {


### PR DESCRIPTION
Detects if `$ref` is to an external `json` schema file, leaves `$ref` intact rather than pointing to `#/definitions`.