### PR TITLE
Media upload and other bugs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -203,6 +203,9 @@ function processMethodList(data) {
     if (path[0] !== '/')
       path = '/' + path;
 
+    // fix broken "complex" paths
+    path = path.replaceAll("{+", "{");
+
     if (!(path in srPaths))
       srPaths[path] = { };
     srPaths[path][httpMethod] = processMethod(method);

--- a/src/index.js
+++ b/src/index.js
@@ -340,9 +340,6 @@ function processMethod(method, options) {
       simpleMethod.parameters = parameters;
       simpleMethod.operationId = method.id + '.simple';
 
-      if ('response' in simpleMethod)
-        response.schema = processSchemaRef(simpleMethod.response);
-
       path = simple.path;
       if (!(path in paths))
         paths[path] = { };
@@ -381,6 +378,9 @@ function processMethod(method, options) {
 
       resumableMethod.parameters = parameters;
       resumableMethod.operationId = method.id + '.resumable';
+
+      // resumable upload doesn't return a schema
+      delete(resumableMethod.responses[200].schema);
 
       path = resumable.path;
       if (!(path in paths))

--- a/src/index.js
+++ b/src/index.js
@@ -340,7 +340,7 @@ function processMediaUpload(method) {
             required: true
           });
           parameters.push({
-            name: 'metatdata',
+            name: 'metadata',
             in: 'body',
             schema: processSchemaRef(request),
             required: true
@@ -352,14 +352,34 @@ function processMediaUpload(method) {
             required: true
           });
         }
+
+        if ('response' in method)
+          response.schema = processSchemaRef(method.response);
+
         break;
+      case 'resumable':
+        if ('request' in method) {
+          var request = method.request;
+          parameters.push({
+            description: 'Upload type. Must be "resumable"',
+            in: 'query',
+            name: 'uploadType',
+            type: 'string',
+            enum: [
+              'resumable'
+            ],
+            required: true
+          });
+          parameters.push({
+            name: request.parameterName || 'body',
+            in: 'body',
+            schema: processSchemaRef(request)
+          });
+        }
     }
 
     if (!_.isEmpty(parameters))
       m.parameters = parameters;
-
-    if ('response' in method)
-      response.schema = processSchemaRef(method.response);
 
     if ('scopes' in method) {
       m.security = _.map(method.scopes, function (scope) {

--- a/src/index.js
+++ b/src/index.js
@@ -330,9 +330,9 @@ function processMediaUpload(method) {
         if ('request' in method) {
           var request = method.request;
           parameters.push({
-            description: 'Upload type. Must be "multipart"',
-            in: 'query',
+            description: 'Upload type. Must be "multipart".',
             name: 'uploadType',
+            in: 'query',
             type: 'string',
             enum: [
               'multipart'
@@ -340,12 +340,14 @@ function processMediaUpload(method) {
             required: true
           });
           parameters.push({
+            description: request.$ref  + ' metadata.',
             name: 'metadata',
             in: 'body',
             schema: processSchemaRef(request),
             required: true
           });
           parameters.push({
+            description: 'The file to upload.',
             name: 'data',
             in: 'formData',
             type: 'file',
@@ -361,7 +363,7 @@ function processMediaUpload(method) {
         if ('request' in method) {
           var request = method.request;
           parameters.push({
-            description: 'Upload type. Must be "resumable"',
+            description: 'Upload type. Must be "resumable".',
             in: 'query',
             name: 'uploadType',
             type: 'string',

--- a/src/index.js
+++ b/src/index.js
@@ -475,6 +475,10 @@ function processDefault(param) {
   if (!('default' in param))
     return undefined;
 
+  // Sometimes, the default value for a boolean is not a string
+  if (param.type === 'boolean' && !_.isString(param.default))
+    param.default = '' + param.default;
+
   assert.ok(_.isString(param.default), 'default parameter must be a string: '+param);
   if (param.type !== 'string')
     param.default = JSON.parse(param.default);


### PR DESCRIPTION
This PR fixes 3 issues:

1. Converts resource methods that `supportsMediaUpload` into 3 separate paths (original, simple, and resumable).
2. Some paths in Google discovery docs have a plus in the url. Example: Datastore has `v1/{+name}`. For these, we simply remove the `+`.
3. A few Google discovery docs provide default boolean values that are not strings. Example: Drive, Gmail, and Youtube.