### PR TITLE
Handle default boolean parameter values that are not strings

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -360,6 +360,10 @@ function processDefault(param) {
   if (!('default' in param))
     return undefined;
 
+  // Sometimes, the default value for a boolean is not a string
+  if (param.type === 'boolean' && !_.isString(param.default))
+    param.default = '' + param.default;
+
   assert.ok(_.isString(param.default), 'default parameter must be a string: '+param);
   if (param.type !== 'string')
     param.default = JSON.parse(param.default);


### PR DESCRIPTION
A few Google discovery docs provide default boolean values that are not strings. Example: Drive, Gmail, and Youtube.

Part of #9 