### PR TITLE
jsonpath: 0.2.2 -> 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,12 +18,12 @@
     "url": "https://github.com/APIs-guru/google-discovery-to-swagger/issues"
   },
   "dependencies": {
-    "urijs": "^1.17.0",
     "json-schema-compatibility": "^1.1.0",
-    "jsonpath": "^0.2.2",
+    "jsonpath": "^1.0.0",
     "lodash": "^4.1.0",
     "mime-db": "^1.21.0",
     "mime-lookup": "^0.0.2",
-    "traverse": "~0.6.6"
+    "traverse": "~0.6.6",
+    "urijs": "^1.17.0"
   }
 }


### PR DESCRIPTION
There are security issues with jsonpath 0.2.2 due to the use of an older version of static-eval. This is fixed in jsonpath 1.0.0.